### PR TITLE
Converted string in array separated by _ and filter words, not spaces

### DIFF
--- a/hackerank/js-practice/snakeCase.js
+++ b/hackerank/js-practice/snakeCase.js
@@ -1,6 +1,6 @@
 function snakeCaseString(phrase) {
   const arrayOfWords = phrase.split("_");
-  const regex = /\S/;
+  const blankCharRegex = /\S/;
   const filterOnlyLetters = arrayOfWords.filter((item) => item.match(regex));
   return filterOnlyLetters.length;
 }

--- a/hackerank/js-practice/snakeCase.js
+++ b/hackerank/js-practice/snakeCase.js
@@ -1,33 +1,34 @@
-
 function snakeCaseString(phrase) {
-	if (phrase.includes('_') === false) {
-		return 0;
-	}
-	let wordsNumber = 1;
-	for (let position in phrase) {
-		if (phrase.charAt(position) === '_') {
-			wordsNumber++;
-		}
-	}
-	return wordsNumber;
+  const arrayOfWords = phrase.split("_");
+  const regex = /\S/;
+  const filterOnlyLetters = arrayOfWords.filter((item) => item.match(regex));
+  return filterOnlyLetters.length;
 }
 
 function checkResults(camelString, expectedResult, func) {
-	const numWords = func(camelString);
-	if (numWords == expectedResult) {
-		console.log("👍");
-	} else {
-		console.log("👎 " + camelString + ' Expected result: ' + expectedResult + " vs " + numWords);
-	}
+  const numWords = func(camelString);
+  if (numWords == expectedResult) {
+    console.log("👍");
+  } else {
+    console.log(
+      "👎 " +
+        camelString +
+        " Expected result: " +
+        expectedResult +
+        " vs " +
+        numWords
+    );
+  }
 }
 
-checkResults('wop_wop', 2, snakeCaseString);
-checkResults('wop_wop_wop', 3, snakeCaseString);
-checkResults('', 0, snakeCaseString);
-checkResults(' wew _wew', 2, snakeCaseString);
-checkResults(' ', 0, snakeCaseString);
-checkResults('         ', 0, snakeCaseString);
-checkResults('_', 0, snakeCaseString);
-checkResults('________', 0, snakeCaseString);
-checkResults('wop', 1, snakeCaseString);
-checkResults('___a_____', 1, snakeCaseString);
+checkResults("wop_wop", 2, snakeCaseString);
+checkResults("wop_wop_wop", 3, snakeCaseString);
+checkResults("", 0, snakeCaseString);
+checkResults(" wew _wew", 2, snakeCaseString);
+checkResults(" ", 0, snakeCaseString);
+checkResults("         ", 0, snakeCaseString);
+checkResults("_", 0, snakeCaseString);
+checkResults("________", 0, snakeCaseString);
+checkResults("wop", 1, snakeCaseString);
+checkResults("___a_____", 1, snakeCaseString);
+checkResults("wop_wop_ ", 2, snakeCaseString);


### PR DESCRIPTION
1. I have transformed the phrase in an array with [.split](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/split) method, specifying that I want each element of the array to be each one that is separated by _ in the original string (string.split('_')).

1. I've created a regular expression to NOT count spaces (/ \S /) --> [example](https://regexr.com/3bvel)

1. I've filtered the array to get only the items without spaces using [.match](https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/String/match) method,  and I've returned the length of the array, because every item of the array must be a word.

`
'wop_   _wop' --> ['wop', '  ', 'wop'] --> ['wop', 'wop'] --> return 2
`

I've added a new checkResult test. And I've forgotten to deactivate the [prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) 😬.